### PR TITLE
Bump sbt and sbt plugins

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.1
+sbt.version=1.8.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.34")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 
-val sbtDevOopsVersion = "2.22.0"
+val sbtDevOopsVersion = "2.23.0"
 addSbtPlugin("io.kevinlee" %% "sbt-devoops-scala"     % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" %% "sbt-devoops-sbt-extra" % sbtDevOopsVersion)
 addSbtPlugin("io.kevinlee" %% "sbt-devoops-starter"   % sbtDevOopsVersion)


### PR DESCRIPTION
Bump sbt and sbt plugins
- sbt: 1.7.1 => 1.8.0
- sbt-devoops: 2.22.0 => 2.23.0