### PR TITLE
Bump Scala and libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,49 +33,49 @@ lazy val props = new {
   val SonatypeCredentialHost = "s01.oss.sonatype.org"
   val SonatypeRepository     = s"https://$SonatypeCredentialHost/service/local"
 
-  val ScalaVersion = "2.13.11"
+  val ScalaVersion = "2.13.12"
 
   val CatsVersion = "2.10.0"
 
-  val CatsEffect3Version = "3.5.1"
+  val CatsEffect3Version = "3.5.3"
 
-  val Fs2Version = "3.7.0"
+  val Fs2Version = "3.9.3"
 
-  val ScodecBits = "1.1.37"
+  val ScodecBits = "1.1.38"
 
   val NewtypeVersion = "0.4.4"
   val RefinedVersion = "0.11.0"
 
-  val KittensVersion = "3.0.0"
+  val KittensVersion = "3.2.0"
 
-  val Http4sVersion = "0.23.23"
+  val Http4sVersion = "0.23.25"
 
-  val PureConfigVersion = "0.17.4"
+  val PureConfigVersion = "0.17.5"
 
-  val CirceVersion = "0.14.5"
+  val CirceVersion = "0.14.6"
 
-  val DoobieVersion = "1.0.0-RC4"
+  val DoobieVersion = "1.0.0-RC5"
 
   val ShapelessVersion = "2.3.10"
 
-  val Ip4sCoreVersion = "3.3.0"
+  val Ip4sCoreVersion = "3.4.0"
 
-  val LogbackVersion = "1.4.11"
+  val LogbackVersion = "1.4.14"
 
   val SvmSubsVersion = "20.2.0"
 
-  val Effectie2Version = "2.0.0-beta11"
-  val LoggerFVersion   = "2.0.0-beta19"
+  val Effectie2Version = "2.0.0-beta14"
+  val LoggerFVersion   = "2.0.0-beta24"
 
   val HedgehogVersion = "0.10.1"
 
-  val HedgehogExtraVersion = "0.4.0"
+  val HedgehogExtraVersion = "0.6.0"
 
-  val ExtrasVersion = "0.41.0"
+  val ExtrasVersion = "0.44.0"
 
-  val Slf4jApiVersion = "2.0.7"
+  val Slf4jApiVersion = "2.0.11"
 
-  val EmbeddedPostgresVersion = "2.0.4"
+  val EmbeddedPostgresVersion = "2.0.6"
 }
 
 lazy val libs = new {


### PR DESCRIPTION
Bump Scala and libraries
* Scala to 2.13.12
* cats-effect to 3.5.3
* fs2 to 3.9.3
* scodec-bits to 1.1.38
* kittens to 3.2.0
* http4s to 0.23.25
* pureconfig to 0.17.5
* circe to 0.14.6
* doobie to 1.0.0-RC5
* ip4s-core to 3.4.0
* logback to 1.4.14
* effectie to 2.0.0-beta14
* logger-f to 2.0.0-beta24
* hedgehog-extra to 0.6.0
* extras to 0.44.0
* slf4j to 2.0.11
* embedded-postgres to 2.0.6