### PR TITLE
Update GitHub Actions workflow and Scala version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,25 +10,16 @@ jobs:
     strategy:
       matrix:
         scala:
-          - { name: "Scala", version: "2.13.8", binary-version: "2", java-version: "11", java-distribution: "temurin" }
+          - { name: "Scala", version: "2.13.12", binary-version: "2", java-version: "11", java-distribution: "temurin" }
 
     steps:
-      - uses: actions/checkout@v2.3.4
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.scala.java-version }}
           distribution: ${{ matrix.scala.java-distribution }}
-
-      - name: Cache SBT
-        uses: actions/cache@v2.1.5
-        with:
-          path: |
-            ~/.ivy2/cache
-            ~/.cache/coursier
-            ~/.sbt
-          key: ${{ runner.os }}-sbt-${{ matrix.scala.binary-version }}-${{ hashFiles('**/*.sbt') }}
-          restore-keys: |
-            ${{ runner.os }}-sbt-${{ matrix.scala.binary-version }}-
+          cache: 'sbt'
+      - uses: sbt/setup-sbt@v1
 
       - name: Build for Scala ${{ matrix.scala.version }}
         run: .github/workflows/sbt-build-all.sh ${{ matrix.scala.version }}


### PR DESCRIPTION
Update GitHub Actions workflow and Scala version

- Upgrade Scala from `2.13.8` to `2.13.12` in `build.yml`
- Update `actions/checkout` from `v2.3.4` to `v4`
- Update `actions/setup-java` from `v3` to `v4`
- Replace manual sbt cache configuration with built-in cache: 'sbt'
- Add `sbt/setup-sbt@v1` for sbt setup